### PR TITLE
Update query

### DIFF
--- a/Persistence/T1053.005-WIN-001.md
+++ b/Persistence/T1053.005-WIN-001.md
@@ -54,7 +54,7 @@ let scheduled_binaries = DeviceProcessEvents
 let untrusted_binaries = scheduled_binaries
 | join kind=leftanti (DeviceFileCertificateInfo | summarize max_trusted=max(IsTrusted) by SHA1 | where max_trusted==1) on SHA1;
 untrusted_binaries
-| invoke FileProfile()
+| invoke FileProfile(SHA1,1000)
 | where IsCertificateValid != 1 // Exclude signed binaries
 | where GlobalPrevalence < 1000
 | join (DeviceProcessEvents | where InitiatingProcessCommandLine == "svchost.exe -k netsvcs -p -s Schedule") on SHA1


### PR DESCRIPTION
FileProfile function checks 100 hashes by default. if there are more hashes to check, the query will produce more false positives.