### PR TITLE
Fixed the data type

### DIFF
--- a/Persistence/T1546.015-WIN-001.md
+++ b/Persistence/T1546.015-WIN-001.md
@@ -52,9 +52,10 @@ Look for the very specific value of "Attribute" in the "ShellFolder" CLSID of a 
 DeviceRegistryEvents
 | where RegistryKey contains "ShellFolder"  and ActionType == "RegistryValueSet" and RegistryValueName =~ "Attributes" 
 //toint automatically converts base10 and base16 strings to int toint("0xFF") == toint("255") == int(0xFF) ==  int(255)
+//here we need to use long type as int in KQL is a 32-bit signed integer
 // We're using >= to make sure that if someone adds an additional flag to this field, it doesn't bypass this hunt.
 // removing any flag will bypass this hunt, but more research is needed to understand which of the flag values are relevant
-| where toint(RegistryValueData) >= int(0xf090013d) 
+| where tolong(RegistryValueData) >= long(0xf090013d) 
 ```
 
 ## Considerations


### PR DESCRIPTION
Int in KQL is a 32-bit signed integer so it turns the flag value into a negativ number. Using long type should fix it.