### PR TITLE
Update AD_Data_Collection_LDAP_Filter_Server_Side_MDI.md

### DIFF
--- a/Discovery/AD_Data_Collection_LDAP_Filter_Server_Side_MDI.md
+++ b/Discovery/AD_Data_Collection_LDAP_Filter_Server_Side_MDI.md
@@ -71,7 +71,7 @@ let timeframe = 1h;
 let suspect_search_filter=dynamic([
     "objectGUID=*", // AD Explorer IOC
     "(schemaIDGUID=*)", // Sharphound IOC
-    "(&(objectclass=computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))" // Sharphound IOC
+    "(&(objectclass=computer)(userAccountControl&8192))" // Sharphound IOC
     "(|(samAccountType=805306368)(samAccountType=805306369)(objectclass=organizationalUnit))", // Sharphound IOC
     "(|(samaccounttype=268435456)(samaccounttype=268435457)(samaccounttype=536870912)(samaccounttype=536870913))", // Sharphound IOC
     "(samAccountType=805306368)(samAccountType=805306369)" // Sharphound IOC
@@ -90,3 +90,4 @@ IdentityQueryEvents
 | Version | Date | Impact | Notes |
 |---------|------|--------|------|
 | 1.0  | 2022-11-11| major | FalconFriday version. |
+| 1.1  | 2022-12-28| minor | Filter tuning. |


### PR DESCRIPTION
MDI seems to not log this [OID](https://ldapwiki.com/wiki/LDAP_MATCHING_RULE_BIT_AND) in full on the server side but rather uses an '&' for the bit mask.

The [client-side detection you have published](https://github.com/FalconForceTeam/FalconFriday/blob/master/Discovery/AD_Data_Collection_LDAP_Filter_Client_Side.md) seems to be still correct since MDE seems to report the full OID.